### PR TITLE
fix: remove manual cert from TLS requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/node_modules
-*.gem
+node_modules
+vendor
 Gemfile.lock
+*.gem

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 #
-# RuboCop is a Ruby static code analyzer and code formatter that tries to enforce many of
-# the guidelines outlined in the community Ruby and Rails
-# style guides.
+# RuboCop is a Ruby static code analyzer and code formatter that tries to enforce many
+# of the guidelines outlined in the community Ruby and Rails style guides.
 #
 # https://docs.rubocop.org/en/latest/
 # https://rubystyle.guide/
@@ -14,3 +13,9 @@ inherit_mode:
     - Exclude
     - IgnoredMethods
     - AllowedMethods
+
+AllCops:
+  NewCops: enable
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/lib/mais/access/dispatcher.rb
+++ b/lib/mais/access/dispatcher.rb
@@ -21,14 +21,13 @@ module MaisAccess
       begin
         # Setup and yield an HTTPS connection to the specified endpoint
         Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-          next yield(uri.path, http)
+          yield(uri.path, http)
         end
       rescue StandardError => e
         Rails.logger.error(e)
+        # Something went wrong, so save our butts and don't them in
+        false
       end
-
-      # Something went wrong, so save our butts and don't them in
-      false
     end
 
     def valid_jwt?

--- a/lib/mais/access/dispatcher.rb
+++ b/lib/mais/access/dispatcher.rb
@@ -2,8 +2,8 @@
 
 module MaisAccess
   module Dispatcher
-    AUTH_ENDPOINT = "#{ENV["MAIS_ACCOUNTS_HOSTNAME"]}/api/authenticate"
-    JWT_ENDPOINT = "#{ENV["MAIS_ACCOUNTS_HOSTNAME"]}/api/verify"
+    AUTH_ENDPOINT = "#{ENV.fetch("MAIS_ACCOUNTS_HOSTNAME")}/api/authenticate"
+    JWT_ENDPOINT = "#{ENV.fetch("MAIS_ACCOUNTS_HOSTNAME")}/api/verify"
     private_constant :AUTH_ENDPOINT
     private_constant :JWT_ENDPOINT
 
@@ -18,46 +18,43 @@ module MaisAccess
     def make_secure_http(endpoint)
       uri = URI(endpoint)
 
-      # Setup https connection and specify certificate bundle if in production
-      if Rails.env.production?
-        http = Net::HTTP.new(uri.host, 443)
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        http.cert_store = OpenSSL::X509::Store.new
-        http.cert_store.set_default_paths
-        http.cert_store.add_file("/etc/pki/tls/certs/server.crt")
-      else
-        # otherwise, just use what was given to us
-        http = Net::HTTP.new(uri.host, uri.port)
+      begin
+        # Setup and yield an HTTPS connection to the specified endpoint
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          next yield(uri.path, http)
+        end
+      rescue StandardError => e
+        Rails.logger.error(e)
       end
 
-      return uri.path, http
+      # Something went wrong, so save our butts and don't them in
+      false
     end
 
     def valid_jwt?
       return false if session[:mais_user].blank? || session[:jwt].blank?
 
-      uri, http = make_secure_http(JWT_ENDPOINT)
+      make_secure_http(JWT_ENDPOINT) do |path, http|
+        # Try to access the verification endpoint with the stored JWT
+        request = Net::HTTP::Get.new(path)
+        request["Authorization"] = session[:jwt]
+        response = http.request(request)
 
-      # Try to access the verification page with the stored JWT
-      request = Net::HTTP::Get.new(uri)
-      request["Authorization"] = session[:jwt]
-      response = http.request(request)
+        # If the server returns HTTP 204 No Content, the token is valid.
+        # `next` is required instead of `return` because `return` exits
+        # without finishing the block execution (cleaning up)
+        next true if response.code == "204"
 
-      # If the server returns HTTP 204 No Content, the token is valid
-      return true if response.code == "204"
-
-      # invalid token, force a session reset
-      set_session
-      false
+        # invalid token, force a session reset
+        set_session
+        false
+      end
     end
 
     def user?(login, password)
-      begin
-        uri, http = make_secure_http(AUTH_ENDPOINT)
-
+      make_secure_http(AUTH_ENDPOINT) do |path, http|
         # Post the credentials to the authentication endpoint
-        request = Net::HTTP::Post.new(uri, { "Content-Type" => "application/json" })
+        request = Net::HTTP::Post.new(path, { "Content-Type" => "application/json" })
         request.body = JSON.generate({ user: { username: login, password: password } })
         response = http.request(request)
 
@@ -67,14 +64,11 @@ module MaisAccess
         # If the user is valid, reset the session and set the current mais user
         if response.code == "201" && body["user"]
           set_session(body["user"], response["Authorization"])
-          return true
+          next true
         end
-      rescue StandardError => e
-        Rails.logger.error(e)
-      end
 
-      # Something went wrong, so save our butts and don't them in
-      false
+        false
+      end
     end
   end
 end

--- a/mais-access.gemspec
+++ b/mais-access.gemspec
@@ -4,11 +4,11 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name = "mais-access"
-  spec.version     = "2.1.1"
+  spec.name        = "mais-access"
+  spec.version     = "2.1.2"
   spec.author      = "Elias Gabriel"
   spec.email       = "me@eliasfgabriel.com"
-  spec.homepage    = "https://github.com/sdbase/mais-access"
+  spec.homepage    = "https://github.com/metabronx/mais-access"
   spec.license     = "CC-BY-NC-SA-4.0"
 
   spec.summary     = "Provides a HTTP/JWT authentication middleware."
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
   spec.metadata    = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
-    "bug_tracker_uri" => "#{spec.homepage}/issues"
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "rubygems_mfa_required" => "true"
   }
 
   spec.required_ruby_version = ">= 2.4.0"
@@ -31,11 +32,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rake", ">= 12.3.3"
 
   spec.add_development_dependency "practical-pig", "~> 1.0"
-  spec.add_development_dependency "rubocop", "~> 0.83.0"
-  spec.add_development_dependency "rubocop-minitest", "~> 0.9"
-  spec.add_development_dependency "rubocop-performance", "~> 1.3"
-  spec.add_development_dependency "rubocop-rails", "~> 2.5"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-minitest"
+  spec.add_development_dependency "rubocop-performance"
+  spec.add_development_dependency "rubocop-rails"
 
   spec.files = `git ls-files`.split("\n")
-  # spec.test_files  = `git ls-files -- test/*`.split("\n")
 end


### PR DESCRIPTION
- Removes manual specification of the TLS certificate, which prevented mais-access for working when the cert was invalid (expired, wrong domain on staging, etc).
- Fixes dangling HTTP connections (connections to MAIS Accounts were never cleaned up/closed)
  - --> possibly relates to increasingly slow app performance on deployed production environments.